### PR TITLE
Add Postman collection for API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ To check the API with Postman, follow these steps:
 3. **Check the response**:
    - The response should indicate that the simulation is starting.
 
+### Importing Postman Collection
+To simplify the process of testing the API, you can import the provided Postman collection:
+
+1. **Download the Postman collection file**:
+   - [Download postman_collection.json](./postman_collection.json)
+
+2. **Import the collection into Postman**:
+   - Open Postman and click on the `Import` button.
+   - Select the downloaded `postman_collection.json` file.
+   - The collection will be imported, and you can use the predefined requests to test the API.
+
 ## Contribution Guidelines
 - Contributions are welcome! Please follow the coding standards and submit issues or pull requests.
 

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,0 +1,109 @@
+{
+	"info": {
+		"_postman_id": "12345678-1234-1234-1234-123456789012",
+		"name": "Simulation Engine API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Start Simulation",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3030/api?time_step=0.1&duration=10.0",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"api"
+					],
+					"query": [
+						{
+							"key": "time_step",
+							"value": "0.1"
+						},
+						{
+							"key": "duration",
+							"value": "10.0"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Stop Simulation",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3030/stop",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"stop"
+					]
+				}
+			}
+		},
+		{
+			"name": "Pause Simulation",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3030/pause",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"pause"
+					]
+				}
+			}
+		},
+		{
+			"name": "Reset Simulation",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3030/reset",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"reset"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Simulations",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3030/simulations",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3030",
+					"path": [
+						"simulations"
+					]
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
Add a Postman collection file and update the README.md to improve the Postman profile setup.

* **Add Postman Collection**
  - Add `postman_collection.json` with predefined requests for the API endpoints including `/api`, `/stop`, `/pause`, `/reset`, and `/simulations`.

* **Update README.md**
  - Add instructions for importing the Postman collection under the "Checking with Postman" section.
  - Include a link to the `postman_collection.json` file for easy download.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/simulation_engine/pull/2?shareId=d95c98b0-b468-43c2-be40-22279a761b6f).