### PR TITLE
fix(ci): add permissions to workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 ---
 name: Rust CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/simulation-engine/security/code-scanning/1](https://github.com/bniladridas/simulation-engine/security/code-scanning/1)

To fix the problem, add a top-level `permissions:` block to the workflow specifying minimal read permissions (usually `contents: read`). This will ensure that all jobs, except those explicitly setting their own `permissions` block (like the existing `release` job), will only be able to read repository contents. Specifically, insert the following block after the `name:` key and before `on:` (on line 3). This change only impacts file `.github/workflows/rust.yml`. No changes to imports, methods, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
