### PR TITLE
fix: remove redundant serde_derive dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,6 @@ dependencies = [
  "rayon",
  "reqwest",
  "serde",
- "serde_derive",
  "serde_json",
  "tokio",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ nalgebra = "0.29" # For high-precision arithmetic
 warp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 log = "0.4"
 env_logger = "0.9"
 pyo3 = { version = "0.24", optional = true }


### PR DESCRIPTION
The serde crate with features = "derive" already includes the derive macros, so serde_derive is unnecessary and can be removed to avoid redundancy.