### PR TITLE
fix: prevent nan in collisions and enable detection

### DIFF
--- a/engine/physics/physics_engine.rs
+++ b/engine/physics/physics_engine.rs
@@ -1,5 +1,8 @@
 use nalgebra::Vector2;
 
+/// Minimum distance threshold to avoid division by very small values in collision calculations
+const MIN_DISTANCE_EPSILON: f32 = 1e-6;
+
 #[derive(Clone, Debug)]
 pub struct Object {
     pub position: Vector2<f32>,
@@ -66,7 +69,7 @@ impl PhysicsEngine {
                 let rad2 = self.objects[j].radius;
                 let diff = pos1 - pos2;
                 let distance = diff.norm();
-                if distance < rad1 + rad2 && distance > 1e-6 {
+                if distance < rad1 + rad2 && distance > MIN_DISTANCE_EPSILON {
                     // Elastic collision in 2D
                     let m1 = self.objects[i].mass;
                     let m2 = self.objects[j].mass;
@@ -123,7 +126,7 @@ impl PhysicsEngine {
         }
 
         // Handle object-object collisions
-        // self.handle_collisions();
+        self.handle_collisions();
 
         for obj in &self.objects {
             log::info!(

--- a/engine/physics/physics_engine.rs
+++ b/engine/physics/physics_engine.rs
@@ -66,7 +66,7 @@ impl PhysicsEngine {
                 let rad2 = self.objects[j].radius;
                 let diff = pos1 - pos2;
                 let distance = diff.norm();
-                if distance < rad1 + rad2 && distance > 0.0 {
+                if distance < rad1 + rad2 && distance > 1e-6 {
                     // Elastic collision in 2D
                     let m1 = self.objects[i].mass;
                     let m2 = self.objects[j].mass;


### PR DESCRIPTION
## Summary
- Prevent NaN in collisions by enforcing a minimum distance check
- Enable collision detection in `simulate`
- Define `MIN_DISTANCE_EPSILON` for maintainability

<details>
<summary>Why this change?</summary>

When two objects occupy the same or nearly the same position, the distance used in collision resolution can approach zero.  
This can lead to:
- Division by extremely small values
- NaN or infinite velocities
- Downstream state corruption in the simulation

Introducing an epsilon threshold ensures numerical stability while preserving correct collision behavior.  
Enabling collisions makes the physics simulation more realistic and complete.
</details>